### PR TITLE
LE2017 Lichfield campaign spending

### DIFF
--- a/local.staffordshire.lichfield-city-north.2017-05-04.csv
+++ b/local.staffordshire.lichfield-city-north.2017-05-04.csv
@@ -1,1 +1,7 @@
-"buyer","buyer_uri","supplier","supplier_uri","currency","total_charged","amount","vat","balance","date","description","unspsc_code","ec_category","transaction_reference","ec_accounting_category"
+buyer,buyer_uri,supplier,supplier_uri,currency,total_charged,amount,vat,balance,date,description,unspsc_code,ec_category,transaction_reference,ec_accounting_category
+Philip John,,"Facebook Ireland, Ltd.",https://opencorporates.com/companies/ie/462932,GBP,20.05,20.05,0,,27/04/17,Facebook advertising,82101603,A,1285957178185316-2505587,campaigning costs
+Philip John,,"Facebook Ireland, Ltd.",https://opencorporates.com/companies/ie/462932,GBP,22.59,22.59,0,,30/04/07,Facebook advertising,82101603,A,1284139485033753-2514533,campaigning costs
+Philip John,,Twitter International Company,https://opencorporates.com/companies/ie/503351,GBP,30,30,5,,02/05/17,Twitter advertising,82101603,A,800000002354930,campaigning costs
+Philip John,,Twitter International Company,https://opencorporates.com/companies/ie/503351,GBP,24,24,4,,09/05/17,Twitter advertising,82101603,A,800000002372615,campaigning costs
+Philip John,,MOO Print Limited,https://opencorporates.com/companies/gb/05121723,GBP,40.19,40.19,6.7,,17/04/17,Business cards,14111604,,252529073,campaigning costs
+Philip John,,Shirtinator AG,,GBP,50.94,50.94,8.49,,17/04/17,Promotional clothing,53100000,,17/04/17-UK0002,campaigning costs


### PR DESCRIPTION
Recording all the spending in the local election campaign for the Lichfield City North division in the Staffordshire County Council elections of 4th May, 2017